### PR TITLE
ci(release): publish to Chrome Web Store on release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: chrome-web-store
     permissions:
       contents: write
     steps:
@@ -60,3 +61,14 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           files: .output/*.zip
           generate_release_notes: true
+
+      - name: Submit to Chrome Web Store
+        if: steps.check_tag.outputs.exists == 'false'
+        run: pnpm wxt submit --chrome-zip .output/*-chrome.zip
+        env:
+          CHROME_EXTENSION_ID: eeadfjedbkhpjbccolcfbhflfckmfcmj
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISH_TARGET: default
+          CHROME_SKIP_SUBMIT_REVIEW: "false"

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ logs/
 .env
 .env.local
 .env.*.local
+.env.submit
 
 # Temporary files
 tmp/


### PR DESCRIPTION
Add `wxt submit` step after the GitHub release creation so each new
version is automatically uploaded to the Chrome Web Store for review.

- Bind the release job to the `chrome-web-store` environment so the
  Chrome OAuth secrets are scoped to release runs only.
- Hardcode the public extension ID and pass non-sensitive flags
  (`CHROME_PUBLISH_TARGET`, `CHROME_SKIP_SUBMIT_REVIEW`) inline.
- Ignore `.env.submit` generated by `wxt-publish-extension init` to
  prevent accidentally committing credentials.