### PR TITLE
chore: Revert to Corepack for pnpm setup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,16 @@ jobs:
           echo "Tag ${{ steps.version.outputs.tag }} already exists. Skipping."
           exit 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        if: steps.check_tag.outputs.exists == 'false'
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         if: steps.check_tag.outputs.exists == 'false'
         with:
           node-version: "24"
-          cache: "pnpm"
+
+      - name: Enable pnpm via Corepack
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          corepack enable
+          pnpm --version
 
       - run: pnpm install --frozen-lockfile
         if: steps.check_tag.outputs.exists == 'false'


### PR DESCRIPTION
## Summary
- The `release` job in `release.yml` used `pnpm/action-setup`, which caused [run 29181109954](https://github.com/wozaki/insights-plus-for-github-projects/actions/runs/29181109954/job/86618758534) to fail while switching to pnpm 11.12.0 with `Cannot use 'in' operator to search for 'integrity' in undefined`
- Applies the same fix as commit 24e1147 (from #98), which resolved the identical issue in `ci.yml` by switching to Corepack

## Test plan
- [ ] Confirm the release workflow succeeds on the next `package.json` update merged to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)