### PR TITLE
ci: Add Bump Version workflow to trigger releases from Actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,53 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version to release (e.g. 1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: ${{ inputs.version }}. Expected format: X.Y.Z"
+            exit 1
+          fi
+
+      - name: Check tag doesn't already exist
+        run: |
+          git fetch --tags
+          if git tag -l "v${{ inputs.version }}" | grep -q .; then
+            echo "Tag v${{ inputs.version }} already exists."
+            exit 1
+          fi
+
+      - name: Bump package.json version
+        run: npm pkg set version="${{ inputs.version }}"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump version to ${{ inputs.version }}"
+          git push origin HEAD:main
+
+      # A push made with GITHUB_TOKEN doesn't fire other workflows' `on: push`
+      # triggers, so release.yml won't start on its own; dispatch it explicitly.
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml --ref main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "package.json"
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "package.json"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.2.3). Leave empty to release the version already in package.json."
+        required: false
+        type: string
 
 jobs:
   release:
@@ -16,6 +21,20 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Bump package.json version
+        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: $VERSION. Expected format: X.Y.Z"
+            exit 1
+          fi
+          npm pkg set version="$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump version to $VERSION"
+          git push origin HEAD:main
 
       - name: Get version from package.json
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,6 @@ on:
     paths:
       - "package.json"
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release (e.g. 1.2.3). Leave empty to release the version already in package.json."
-        required: false
-        type: string
 
 jobs:
   release:
@@ -21,20 +16,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - name: Bump package.json version
-        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
-        run: |
-          VERSION="${{ inputs.version }}"
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version: $VERSION. Expected format: X.Y.Z"
-            exit 1
-          fi
-          npm pkg set version="$VERSION"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "Bump version to $VERSION"
-          git push origin HEAD:main
 
       - name: Get version from package.json
         id: version

--- a/README.md
+++ b/README.md
@@ -163,17 +163,29 @@ pnpm wxt zip
 
 ### Release
 
-To create a new release:
+To create a new release, run the **Bump Version** workflow from the [Actions tab](../../actions/workflows/bump-version.yml) (or `gh workflow run bump-version.yml -f version=1.2.3`), entering the new version number.
+
+This will automatically:
+- Update the `version` field in `package.json` and commit it to `main`
+- Trigger the **Release** workflow, which:
+  - Creates a git tag (e.g., `v1.2.3`)
+  - Builds the extension
+  - Creates a GitHub Release with the built `.zip` file
+  - Submits the build to the Chrome Web Store
+
+If the tag already exists, the release workflow will skip the release.
+
+<details>
+<summary>Manual alternative</summary>
+
+You can also trigger a release by pushing the version bump yourself:
 
 1. Update the `version` field in `package.json`
 2. Commit and push to the `main` branch
 
-GitHub Actions will automatically:
-- Create a git tag (e.g., `v1.0.0`)
-- Build the extension
-- Create a GitHub Release with the built `.zip` file
+This triggers the same Release workflow.
 
-If the tag already exists, the workflow will skip the release.
+</details>
 
 
 ### Tech Stack


### PR DESCRIPTION
## Summary
- New `.github/workflows/bump-version.yml`: a `workflow_dispatch` that takes a `version` input, validates the format, checks the tag doesn't already exist, sets `package.json`'s version via `npm pkg set`, commits as `github-actions[bot]`, and pushes to `main`.
- A push made with `GITHUB_TOKEN` doesn't fire another workflow's `on: push` trigger, so the last step explicitly runs `gh workflow run release.yml --ref main` to hand off to the existing release workflow.
- `.github/workflows/release.yml` itself is unchanged in logic — it keeps a bare `workflow_dispatch` (for the explicit dispatch above, and for manual re-runs) alongside its existing push trigger, and still just reads the version from `package.json`, builds, tags, releases, and submits to the Chrome Web Store.
- Updated the README's Release section to document running "Bump Version" from the Actions tab as the primary flow, keeping the manual bump-and-push as a documented fallback.

## Test plan
- [ ] After merge, run `gh workflow run bump-version.yml -f version=X.Y.Z` and confirm: package.json is bumped and committed to main, and the Release workflow runs against that version end-to-end (tag, GitHub Release, Chrome Web Store submission)
- [ ] Confirm the existing manual flow (bump package.json locally, push to main) still triggers the Release workflow unchanged