### PR TITLE
fix(date-alerts): don't show Configure UI on the Roadmap view

### DIFF
--- a/src/entrypoints/date-alerts.content/__tests__/table-scraper.test.ts
+++ b/src/entrypoints/date-alerts.content/__tests__/table-scraper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getGrid,
+  getTableRoot,
   getColumnName,
   getVisibleColumnNames,
   getColumnIndex,
@@ -74,6 +75,22 @@ describe('getGrid', () => {
 
   it('returns null when absent', () => {
     expect(getGrid()).toBeNull();
+  });
+});
+
+describe('getTableRoot', () => {
+  it('finds the table root ancestor (list/table layout)', () => {
+    const grid = buildGrid([]);
+    const tableRoot = document.createElement('div');
+    tableRoot.className = 'table-module__tableRoot__abc123';
+    grid.parentElement!.insertBefore(tableRoot, grid);
+    tableRoot.appendChild(grid);
+    expect(getTableRoot(grid)).toBe(tableRoot);
+  });
+
+  it('returns null when the grid has no table root ancestor (e.g. Roadmap view)', () => {
+    const grid = buildGrid([]);
+    expect(getTableRoot(grid)).toBeNull();
   });
 });
 

--- a/src/entrypoints/date-alerts.content/index.ts
+++ b/src/entrypoints/date-alerts.content/index.ts
@@ -16,6 +16,7 @@ import { createConfigView, CONFIG_VIEW_CLASS } from './config-view';
 import { applyAlert, removeAllAnnotations } from './cell-annotator';
 import {
   getGrid,
+  getTableRoot,
   getDataRows,
   getRowContentId,
   getColumnIndex,
@@ -59,6 +60,12 @@ export default defineContentScript({
       const grid = await waitForGrid(() => token === initToken);
       if (!grid || token !== initToken) return;
 
+      // Other layouts (e.g. Roadmap) also render a `[role="grid"]`; only the
+      // list/table layout has this ancestor, so treat its absence as "not the
+      // list view" rather than mounting against the grid directly.
+      const tableRoot = getTableRoot(grid);
+      if (!tableRoot) return;
+
       const key = projectKey();
       if (!key) return;
 
@@ -75,7 +82,7 @@ export default defineContentScript({
       // exist on the project without being added here, and picking one would
       // save but never find a cell to annotate.
       const dateFields = filterFieldsVisibleAsColumns(grid, metaOnly.dateFields);
-      mountConfigView(grid, key, dateFields, metaOnly.statusOptionList, mapping);
+      mountConfigView(tableRoot, key, dateFields, metaOnly.statusOptionList, mapping);
 
       if (isValidMapping(mapping)) {
         renderAlerts(grid, mapping);
@@ -86,7 +93,7 @@ export default defineContentScript({
     }
 
     function mountConfigView(
-      grid: HTMLElement,
+      anchor: HTMLElement,
       key: string,
       dateFields: DateFieldOption[],
       statusOptions: DateFieldOption[],
@@ -100,7 +107,6 @@ export default defineContentScript({
         onSave: (next) => setMapping(key, next),
       });
 
-      const anchor = grid.closest('[class*="table-module__tableRoot"]') ?? grid;
       anchor.parentElement?.insertBefore(view, anchor);
     }
 

--- a/src/entrypoints/date-alerts.content/table-scraper.ts
+++ b/src/entrypoints/date-alerts.content/table-scraper.ts
@@ -5,9 +5,25 @@
 
 import type { DateFieldOption } from './types';
 
-/** The list-view grid element, or null when not present (e.g. board view). */
+/**
+ * The `[role="grid"]` element, or null when not present (e.g. board view).
+ *
+ * Note: this alone doesn't mean we're in the list/table layout — the Roadmap
+ * view also renders a `[role="grid"]`. Use `getTableRoot` to confirm.
+ */
 export function getGrid(doc: Document = document): HTMLElement | null {
   return doc.querySelector<HTMLElement>('[role="grid"]');
+}
+
+/**
+ * The list-view table root ancestor of the grid, or null when the grid
+ * belongs to a different layout that happens to also render a
+ * `[role="grid"]` (e.g. Roadmap). This feature's cell annotations only make
+ * sense in the table layout, so callers should treat a null result as "not
+ * the list view" rather than falling back to the grid itself.
+ */
+export function getTableRoot(grid: HTMLElement): HTMLElement | null {
+  return grid.closest<HTMLElement>('[class*="table-module__tableRoot"]');
 }
 
 /** Clean field name shown in a column header (e.g. "Start on"). */


### PR DESCRIPTION
## Summary
- The Date Field Alerts Configure UI was appearing on the Roadmap view (e.g. `/projects/N/views/M` with a roadmap layout), not just the List view it's meant for.
- Root cause: the Roadmap layout also renders a `[role="grid"]` element, and the mount logic only checked for that grid's presence, falling back to the grid itself as the anchor when the list-view-specific `table-module__tableRoot` ancestor wasn't found — so it mounted anyway.
- Fix: added `getTableRoot()` in `table-scraper.ts` and made `index.ts` bail out early when it's missing, instead of treating the grid as a fallback anchor.
- Verified against a real project (board / list / roadmap views) that only the list/table layout has both `[role="grid"]` and the `table-module__tableRoot` ancestor; board has neither, roadmap has the grid but not the table root.

## Test plan
- [x] `pnpm vitest run src/entrypoints/date-alerts.content/` — 151 tests pass (added coverage for `getTableRoot`)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Manually inspected DOM of a live board/list/roadmap project to confirm the grid vs. table-root distinction holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)